### PR TITLE
refactor(config): 直接用变量指定后端地址

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-# 这是一个示例环境变量文件，请复制为.env.development并填入实际的值
-# 测试用API地址
-VITE_API_TARGET=http://127.0.0.1:5000

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,9 +5,7 @@ import Pages from "vite-plugin-pages";
 
 // https://vite.dev/config/
 import type { UserConfig } from "vite";
-import * as fs from "fs";
 import * as path from "path";
-import dotenv from "dotenv";
 
 export default defineConfig(({ mode }) => {
   const buildTime = new Date().toISOString();
@@ -44,17 +42,10 @@ export default defineConfig(({ mode }) => {
   };
 
   if (mode === "development") {
-    const envPath = path.resolve(process.cwd(), ".env.development");
-    if (fs.existsSync(envPath)) {
-      const envConfig = dotenv.parse(fs.readFileSync(envPath));
-      for (const k in envConfig) {
-        process.env[k] = envConfig[k];
-      }
-    }
     baseConfig.server = {
       proxy: {
         "/api": {
-          target: process.env.VITE_API_TARGET,
+          target: "http://localhost:25774",
           changeOrigin: true,
           ws: true,
         },


### PR DESCRIPTION
原来去读取.env.development好像有点绕（?
改成了直接定义target，这样直观一点