### PR TITLE
feat: add real-time network speed display with configurable status cards

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -172,6 +172,8 @@
   "current_time": "Current Time",
   "region_overview": "Region",
   "traffic_overview": "Traffic Overview",
+  "network_speed": "Network Speed",
+  "status_settings": "Status Settings",
   "account_settings": {
     "github_account": "GitHub Account",
     "github_bound": "Bound",

--- a/src/i18n/locales/zh_CN.json
+++ b/src/i18n/locales/zh_CN.json
@@ -150,6 +150,8 @@
   "current_time": "当前时间",
   "region_overview": "点亮地区",
   "traffic_overview": "流量概览",
+  "network_speed": "网络速率",
+  "status_settings": "状态显示设置",
   "account_settings": {
     "github_account": "GitHub账户",
     "github_bound": "已绑定",

--- a/src/i18n/locales/zh_TW.json
+++ b/src/i18n/locales/zh_TW.json
@@ -150,6 +150,8 @@
   "current_time": "當前時間",
   "region_overview": "點亮地區",
   "traffic_overview": "流量概覽",
+  "network_speed": "網路速率",
+  "status_settings": "狀態顯示設定",
   "account_settings": {
     "github_account": "GitHub帳戶",
     "github_bound": "已綁定",


### PR DESCRIPTION
- Added formatSpeed function for intelligent unit display (B/s, KB/s, MB/s, GB/s)
- Implemented fifth status card showing total real-time network speed
- Changed layout from flex to responsive grid (1/3/5 columns)
- Added settings button with toggles for each status card visibility
- Implemented localStorage persistence for user preferences
- Added i18n translations for "network_speed" and "status_settings"

