### PR TITLE
fix: correct network speed display to show upload/download separately

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -48,12 +48,6 @@ const Index = () => {
     }
     //#endregion
     
-    // Calculate total network speed
-    const totalNetworkSpeed = live_data?.data?.data
-      ? Object.values(live_data.data.data).reduce((acc, node) => {
-          return acc + (node.network.up || 0) + (node.network.down || 0);
-        }, 0)
-      : 0;
     return (
       <>
         <Callouts />
@@ -222,7 +216,31 @@ const Index = () => {
                 align="center"
               >
                 <Text>{t("network_speed")}</Text>
-                <Text>{formatSpeed(totalNetworkSpeed)}</Text>
+                <Text>
+                  {"↑ " +
+                    formatSpeed(
+                      live_data?.data?.data
+                        ? Object.values(live_data.data.data).reduce(
+                            (acc, node) => {
+                              return acc + (node.network.up || 0);
+                            },
+                            0
+                          )
+                        : 0
+                    )}{" "}
+                  /{" "}
+                  {"↓ " +
+                    formatSpeed(
+                      live_data?.data?.data
+                        ? Object.values(live_data.data.data).reduce(
+                            (acc, node) => {
+                              return acc + (node.network.down || 0);
+                            },
+                            0
+                          )
+                        : 0
+                    )}
+                </Text>
               </Flex>
             )}
           </div>


### PR DESCRIPTION
- Remove incorrect totalNetworkSpeed calculation that combined up/down speeds
- Display upload and download speeds separately with ↑/↓ indicators
- Consistent with network speed format used elsewhere in the app
- Change the wrong PR to the right one
This fixes the network speed status card to properly show individual upload and download rates instead of a combined total.