### PR TITLE
fix: add missing up/down arrows in total network speed display

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -92,18 +92,18 @@ const Index = () => {
         key: 'networkSpeed',
         title: t("network_speed"),
         getValue: () => live_data?.data?.data
-          ? `${formatSpeed(
+          ? `↑ ${formatSpeed(
             Object.values(live_data.data.data).reduce(
               (acc, node) => acc + (node.network.up || 0),
               0
             )
-          )} / ${formatSpeed(
+          )} ↓ ${formatSpeed(
             Object.values(live_data.data.data).reduce(
               (acc, node) => acc + (node.network.down || 0),
               0
             )
           )}`
-          : "0 B/s / 0 B/s",
+          : "↑ 0 B/s ↓ 0 B/s",
         visible: statusCardsVisibility.networkSpeed
       }
     ];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -97,13 +97,13 @@ const Index = () => {
               (acc, node) => acc + (node.network.up || 0),
               0
             )
-          )} ↓ ${formatSpeed(
+          )} | ↓ ${formatSpeed(
             Object.values(live_data.data.data).reduce(
               (acc, node) => acc + (node.network.down || 0),
               0
             )
           )}`
-          : "↑ 0 B/s ↓ 0 B/s",
+          : "↑ 0 B/s | ↓ 0 B/s",
         visible: statusCardsVisibility.networkSpeed
       }
     ];


### PR DESCRIPTION
Add ↑ ↓ arrow indicators to the network speed card on the homepage to maintain consistency with the display style in other parts of the project

🤖 Generated with [Claude Code](https://claude.ai/code)