### PR TITLE
fix: fix network speed display format

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -92,18 +92,18 @@ const Index = () => {
         key: 'networkSpeed',
         title: t("network_speed"),
         getValue: () => live_data?.data?.data
-          ? `${formatSpeed(
+          ? `↑ ${formatSpeed(
             Object.values(live_data.data.data).reduce(
               (acc, node) => acc + (node.network.up || 0),
               0
             )
-          )} / ${formatSpeed(
+          )} | ↓ ${formatSpeed(
             Object.values(live_data.data.data).reduce(
               (acc, node) => acc + (node.network.down || 0),
               0
             )
           )}`
-          : "0 B/s / 0 B/s",
+          : "↑ 0 B/s | ↓ 0 B/s",
         visible: statusCardsVisibility.networkSpeed
       }
     ];


### PR DESCRIPTION
- Add missing up/down arrow indicators
- Replace slash with pipe separator for better visual clarity
- Format: "↑ upload speed | ↓ download speed"

🤖 Generated with [Claude Code](https://claude.ai/code)