### PR TITLE
Fixed install command generated by web UI

### DIFF
--- a/src/components/admin/NodeTable/NodeFunction.tsx
+++ b/src/components/admin/NodeTable/NodeFunction.tsx
@@ -83,7 +83,7 @@ export function ActionsCell({ row }: { row: Row<z.infer<typeof schema>> }) {
     switch (selectedPlatform) {
       case "linux":
         finalCommand =
-          `bash <(curl -sL https://raw.githubusercontent.com/komari-monitor/komari-agent/refs/heads/main/install.sh) ` +
+          `wget -qO- https://raw.githubusercontent.com/komari-monitor/komari-agent/refs/heads/main/install.sh | bash -s -- ` +
           args.join(" ");
         break;
       case "windows":

--- a/src/components/admin/NodeTable/NodeFunction.tsx
+++ b/src/components/admin/NodeTable/NodeFunction.tsx
@@ -83,7 +83,7 @@ export function ActionsCell({ row }: { row: Row<z.infer<typeof schema>> }) {
     switch (selectedPlatform) {
       case "linux":
         finalCommand =
-          `wget -qO- https://raw.githubusercontent.com/komari-monitor/komari-agent/refs/heads/main/install.sh | bash -s -- ` +
+          `wget -qO- https://raw.githubusercontent.com/komari-monitor/komari-agent/refs/heads/main/install.sh | sudo bash -s -- ` +
           args.join(" ");
         break;
       case "windows":

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -653,7 +653,7 @@ function GenerateCommandButton({ node, settings }: { node: NodeDetail, settings:
     let finalCommand = "";
     switch (selectedPlatform) {
       case "linux":
-        finalCommand = `wget -qO- ${scriptUrl}) | bash -s -- ` + args.join(" ");
+        finalCommand = `wget -qO- ${scriptUrl} | sudo bash -s -- ` + args.join(" ");
         break;
       case "windows":
         finalCommand =

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -653,7 +653,7 @@ function GenerateCommandButton({ node, settings }: { node: NodeDetail, settings:
     let finalCommand = "";
     switch (selectedPlatform) {
       case "linux":
-        finalCommand = `bash <(curl -sL ${scriptUrl}) ` + args.join(" ");
+        finalCommand = `wget -qO- ${scriptUrl}) | bash -s -- ` + args.join(" ");
         break;
       case "windows":
         finalCommand =


### PR DESCRIPTION
### Describe the Bug

Installing with the generated command from the web interface fails.


### To Reproduce

Try to install with the instructions you are given in the web interface:

_sudo bash <(curl -sL https://raw.githubusercontent.com/komari-monitor/komari-agent/refs/heads/main/install.sh) -e \<args\>_

This always returns the exact same error:
**bash: /dev/fd/63: No such file or directory**

### Expected Behavior

Installation should proceed.

I have tested on 7 machines, 3 fresh installs, 4 existing installs used for 1 month up to ~4 years.
All give the exact same error as above.

### Environment
OS: Debian 12, 13, Ubuntu 24

### Solution:

Replace
_sudo bash <(curl -sL https://raw.githubusercontent.com/komari-monitor/komari-agent/refs/heads/main/install.sh) \<args\>_

with

_wget -qO- https://raw.githubusercontent.com/komari-monitor/komari-agent/refs/heads/main/install.sh | sudo bash -s -- \<args\>_