### PR TITLE
feat: 按名称排序延迟检测任务

### DIFF
--- a/src/pages/admin/pingTask_Task.tsx
+++ b/src/pages/admin/pingTask_Task.tsx
@@ -46,7 +46,11 @@ export const TaskView = ({ pingTasks }: { pingTasks: PingTask[] }) => {
           __originalCount: original.length,
         };
       })
-      .sort((a, b) => (b.id ?? 0) - (a.id ?? 0));
+      .sort((a, b) => {
+        const aKey = (a as any).name ?? String(a.id ?? 0);
+        const bKey = (b as any).name ?? String(b.id ?? 0);
+        return aKey.localeCompare(bKey, undefined, { sensitivity: "base", numeric: true });
+});
   }, [pingTasks, nodeDetail]);
 
   return (


### PR DESCRIPTION
延迟任务的ID似乎没法自行修改, 目前也没提供手动排序功能, 那么根据可自定义的任务名间接提供排序功能可能比较简单

不过是不是得跟后端打包一起才能测试? 试了下扔主题包上去后端依然发送旧版js, 所以主题包只对前端的前台有效?