### PR TITLE
fix: 保持服务器视图下延迟任务对话框内排序与任务视图下一致

### DIFF
--- a/src/pages/admin/pingTask_Server.tsx
+++ b/src/pages/admin/pingTask_Server.tsx
@@ -152,7 +152,7 @@ const ServerRow: React.FC<{
                 <Selector
                   value={selectedIds}
                   onChange={setSelectedIds}
-                  items={[...pingTasks.filter((t) => t.id !== undefined)].reverse()}
+                  items={[...pingTasks.filter((t) => t.id !== undefined)]}
                   getId={(task) => String(task.id)}
                   getLabel={(task) => (
                     <span className="text-sm">


### PR DESCRIPTION
上次添加延迟任务手动排序后没有清理干净, 服务器视图下顺序反了
任务视图顺序:
<img width="294" height="748" alt="image" src="https://github.com/user-attachments/assets/b1a1805c-e0e3-46f4-ad2d-c411784169a5" />

修改前:
<img width="976" height="546" alt="image" src="https://github.com/user-attachments/assets/032c0df2-2822-4d4a-aff0-370eadfa57ac" />

修改后:
<img width="982" height="565" alt="image" src="https://github.com/user-attachments/assets/89bc08a2-7c73-439d-8b43-327e149bdefe" />
