### PR TITLE
style: 远程执行命令框用等宽字体

### DIFF
--- a/src/pages/admin/exec.tsx
+++ b/src/pages/admin/exec.tsx
@@ -270,6 +270,7 @@ const ExecContent = () => {
                         onChange={(e) => setCommand(e.target.value)}
                         placeholder={t("exec.commandPlaceholder")}
                         size="3"
+                        style={{ fontFamily: "var(--font-mono)" }}
                     >
                         <TextField.Slot>
                             <Terminal size={16} />


### PR DESCRIPTION
想吐槽好久了, 远程执行那个输入框竟然不是等宽字体