### PR TITLE
feat(remote-exec): 支持多行远程命令执行并优化命令输入体验

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -303,7 +303,7 @@
   "exec": {
     "allCompleted": "All tasks executed successfully",
     "command": "Execute command",
-    "commandPlaceholder": "whoami",
+    "commandPlaceholder": "whoami (use Shift+Enter to start a new line)",
     "description": "Remotely execute commands on selected nodes",
     "errors": {
       "emptyCommand": "The command cannot be empty.",

--- a/src/i18n/locales/id_ID.json
+++ b/src/i18n/locales/id_ID.json
@@ -303,7 +303,7 @@
   "exec": {
     "allCompleted": "Semua tugas telah selesai dieksekusi",
     "command": "Perintah",
-    "commandPlaceholder": "whoami",
+    "commandPlaceholder": "whoami (gunakan Shift+Enter untuk baris baru)",
     "description": "Eksekusi perintah jarak jauh pada node yang dipilih",
     "errors": {
       "emptyCommand": "Perintah tidak boleh kosong.",

--- a/src/i18n/locales/ja_JP.json
+++ b/src/i18n/locales/ja_JP.json
@@ -303,7 +303,7 @@
   "exec": {
     "allCompleted": "すべてのタスクが完了しました",
     "command": "コマンドを実行",
-    "commandPlaceholder": "whoami",
+    "commandPlaceholder": "whoami（Shift+Enter で改行）",
     "description": "選択したノードでリモートコマンドを実行",
     "errors": {
       "emptyCommand": "コマンドは空にできません",

--- a/src/i18n/locales/zh_CN.json
+++ b/src/i18n/locales/zh_CN.json
@@ -303,7 +303,7 @@
   "exec": {
     "allCompleted": "所有任务执行完成",
     "command": "执行命令",
-    "commandPlaceholder": "whoami",
+    "commandPlaceholder": "whoami（使用 Shift+Enter 换行）",
     "description": "在选定的节点上远程执行命令",
     "errors": {
       "emptyCommand": "命令不能为空",

--- a/src/i18n/locales/zh_TW.json
+++ b/src/i18n/locales/zh_TW.json
@@ -303,7 +303,7 @@
   "exec": {
     "allCompleted": "所有任務執行完成",
     "command": "執行命令",
-    "commandPlaceholder": "whoami",
+    "commandPlaceholder": "whoami（使用 Shift+Enter 換行）",
     "description": "在選定的節點上遠程執行命令",
     "errors": {
       "emptyCommand": "命令不能為空",

--- a/src/pages/admin/exec.tsx
+++ b/src/pages/admin/exec.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo, type KeyboardEvent } from "react";
 import Loading from "@/components/loading";
 import { NodeDetailsProvider, useNodeDetails } from "@/contexts/NodeDetailsContext";
 import { useTranslation } from "react-i18next";
@@ -6,12 +6,11 @@ import {
     Button,
     Card,
     Flex,
-    TextField,
     Text,
     Separator,
     Badge
 } from "@radix-ui/themes";
-import { Play, Terminal, AlertCircle, CheckCircle2, Copy, Clock } from "lucide-react";
+import { Play, AlertCircle, CheckCircle2, Copy, Clock } from "lucide-react";
 import { toast } from "sonner";
 import NodeSelector from "@/components/NodeSelector";
 import { SettingCardCollapse } from "@/components/admin/SettingCard";
@@ -51,6 +50,11 @@ interface TaskResultResponse {
     data?: TaskResult[];
 }
 
+const COMMAND_EDITOR_COLLAPSED_LINES = 3;
+const COMMAND_EDITOR_LINE_HEIGHT = 24;
+const COMMAND_EDITOR_VERTICAL_PADDING = 24;
+const COMMAND_EDITOR_COLLAPSED_HEIGHT = COMMAND_EDITOR_COLLAPSED_LINES * COMMAND_EDITOR_LINE_HEIGHT + COMMAND_EDITOR_VERTICAL_PADDING;
+
 const ExecPage = () => {
     return (
         <NodeDetailsProvider>
@@ -68,10 +72,30 @@ const ExecContent = () => {
     const [results, setResults] = useState<TaskResult[]>([]);
     const [taskId, setTaskId] = useState<string | null>(null);
     const [polling, setPolling] = useState(false);
+    const [commandFocused, setCommandFocused] = useState(false);
+    const [commandEditorHeight, setCommandEditorHeight] = useState(COMMAND_EDITOR_COLLAPSED_HEIGHT);
 
     // 使用 useRef 来保存轮询相关的引用
-    const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
-    const pollingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const commandTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+    const commandLineCount = useMemo(() => {
+        return command === "" ? 1 : command.split("\n").length;
+    }, [command]);
+
+    const commandLineLabels = useMemo(() => {
+        if (commandFocused || commandLineCount <= COMMAND_EDITOR_COLLAPSED_LINES) {
+            return Array.from({ length: commandLineCount }, (_, index) => String(index + 1));
+        }
+
+        const visibleNumberedLines = COMMAND_EDITOR_COLLAPSED_LINES - 1;
+        const remainingLines = commandLineCount - visibleNumberedLines;
+        return [
+            ...Array.from({ length: visibleNumberedLines }, (_, index) => String(index + 1)),
+            `+${remainingLines}`,
+        ];
+    }, [commandFocused, commandLineCount]);
 
     // 清理轮询的函数
     const clearPolling = () => {
@@ -92,6 +116,23 @@ const ExecContent = () => {
             clearPolling();
         };
     }, []);
+
+    useEffect(() => {
+        const textarea = commandTextareaRef.current;
+        if (!textarea) {
+            return;
+        }
+
+        if (!commandFocused) {
+            textarea.scrollTop = 0;
+            setCommandEditorHeight(COMMAND_EDITOR_COLLAPSED_HEIGHT);
+            return;
+        }
+
+        textarea.style.height = "auto";
+        setCommandEditorHeight(Math.max(COMMAND_EDITOR_COLLAPSED_HEIGHT, textarea.scrollHeight));
+        textarea.style.height = "100%";
+    }, [command, commandFocused]);
 
     if (isLoading) {
         return <Loading />;
@@ -190,7 +231,7 @@ const ExecContent = () => {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                    command: command.trim(),
+                    command,
                     clients: selectedNodes,
                 }),
             });
@@ -218,6 +259,17 @@ const ExecContent = () => {
             toast.error(errorMessage);
         } finally {
             setExecuting(false);
+        }
+    };
+
+    const handleCommandKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+        if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) {
+            return;
+        }
+
+        event.preventDefault();
+        if (!executing) {
+            executeCommand();
         }
     };
 
@@ -265,16 +317,42 @@ const ExecContent = () => {
                     <label className="text-xl font-bold">
                         {t("exec.command")}
                     </label>
-                    <TextField.Root
-                        value={command}
-                        onChange={(e) => setCommand(e.target.value)}
-                        placeholder={t("exec.commandPlaceholder")}
-                        size="3"
+                    <div
+                        className="grid grid-cols-[3.75rem_minmax(0,1fr)] overflow-hidden rounded-md border border-[var(--gray-a7)] bg-[var(--color-surface)] transition-[height,border-color,box-shadow] duration-200 focus-within:border-[var(--accent-8)] focus-within:shadow-[0_0_0_1px_var(--accent-8)]"
+                        style={{ height: commandEditorHeight }}
                     >
-                        <TextField.Slot>
-                            <Terminal size={16} />
-                        </TextField.Slot>
-                    </TextField.Root>
+                        <div
+                            aria-hidden="true"
+                            className="select-none overflow-hidden border-r border-[var(--gray-a5)] bg-[var(--gray-2)] px-2 py-3 text-right font-mono text-xs leading-6 text-[var(--gray-11)]"
+                        >
+                            {commandLineLabels.map((label, index) => (
+                                <div
+                                    key={`${label}-${index}`}
+                                    className={label.startsWith("+") ? "font-medium text-[var(--accent-11)]" : undefined}
+                                >
+                                    {label}
+                                </div>
+                            ))}
+                        </div>
+                        <textarea
+                            ref={commandTextareaRef}
+                            value={command}
+                            onChange={(e) => setCommand(e.target.value)}
+                            onFocus={() => setCommandFocused(true)}
+                            onBlur={() => setCommandFocused(false)}
+                            onKeyDown={handleCommandKeyDown}
+                            placeholder={t("exec.commandPlaceholder")}
+                            rows={COMMAND_EDITOR_COLLAPSED_LINES}
+                            wrap="soft"
+                            spellCheck={false}
+                            className="h-full w-full resize-none border-0 bg-transparent px-3 py-3 font-mono text-sm leading-6 text-[var(--gray-12)] outline-none placeholder:text-[var(--gray-9)]"
+                            style={{
+                                overflowY: "hidden",
+                                overflowWrap: "break-word",
+                                whiteSpace: "pre-wrap",
+                            }}
+                        />
+                    </div>
 
 
                     <div>


### PR DESCRIPTION
<img width="500" alt="Animation" src="https://github.com/user-attachments/assets/a4d672ef-7bf0-4194-aa82-0872a2798f27" />

## 变更说明

本次变更为远程命令执行增加多行命令支持，并减少命令内容在前端、后端和 Agent 执行链路中的额外转义影响。

主要改动：

- komari-web <this>
  - 将远程执行命令输入框改为支持多行的命令编辑器
  - 输入框聚焦时按内容自动展开高度，失焦后收起到约 3 行
  - 增加行号显示，收起状态下显示剩余隐藏行数
  - 使用等宽字体、启用自动换行
  - 保留原始命令内容提交，不再提交前 trim
  - 占位提示改为单行示例，并提示使用 Shift+Enter 换行

- komari https://github.com/komari-monitor/komari/pull/543
  - 后端仅拒绝纯空白命令
  - 保留原始 command 字符串进入任务创建和下发流程

- komari-agent https://github.com/komari-monitor/komari-agent/pull/97
  - Unix 下改为通过 sh -s 从 stdin 执行脚本内容，避免把用户命令拼进 sh -c 参数
  - Windows 下改为写入临时 PowerShell 脚本并通过 -File 执行，避免拼接到 -Command
  - 增加多行命令、引号、通配符相关的聚焦测试