### PR TITLE
fix(remote-exec): 完善多行远程命令编辑器稳定性

### DIFF
--- a/src/pages/admin/exec.tsx
+++ b/src/pages/admin/exec.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo, type KeyboardEvent } from "react";
+import { useState, useRef, useEffect, useMemo, type CSSProperties, type KeyboardEvent } from "react";
 import Loading from "@/components/loading";
 import { NodeDetailsProvider, useNodeDetails } from "@/contexts/NodeDetailsContext";
 import { useTranslation } from "react-i18next";
@@ -50,10 +50,12 @@ interface TaskResultResponse {
     data?: TaskResult[];
 }
 
+const COMMAND_EDITOR_ID = "remote-exec-command-editor";
 const COMMAND_EDITOR_COLLAPSED_LINES = 3;
-const COMMAND_EDITOR_LINE_HEIGHT = 24;
-const COMMAND_EDITOR_VERTICAL_PADDING = 24;
-const COMMAND_EDITOR_COLLAPSED_HEIGHT = COMMAND_EDITOR_COLLAPSED_LINES * COMMAND_EDITOR_LINE_HEIGHT + COMMAND_EDITOR_VERTICAL_PADDING;
+const COMMAND_EDITOR_LINE_HEIGHT_VAR = "--command-editor-line-height";
+const COMMAND_EDITOR_VERTICAL_PADDING_VAR = "--command-editor-vertical-padding";
+const COMMAND_EDITOR_COLLAPSED_HEIGHT = `calc(${COMMAND_EDITOR_COLLAPSED_LINES} * var(${COMMAND_EDITOR_LINE_HEIGHT_VAR}) + var(${COMMAND_EDITOR_VERTICAL_PADDING_VAR}))`;
+const COMMAND_EDITOR_LINE_NUMBER_LIMIT = 500;
 
 const ExecPage = () => {
     return (
@@ -79,13 +81,25 @@ const ExecContent = () => {
     const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const commandTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+    const commandLineGutterRef = useRef<HTMLDivElement | null>(null);
 
     const commandLineCount = useMemo(() => {
         return command === "" ? 1 : command.split("\n").length;
     }, [command]);
 
     const commandLineLabels = useMemo(() => {
-        if (commandFocused || commandLineCount <= COMMAND_EDITOR_COLLAPSED_LINES) {
+        if (commandFocused) {
+            const renderedLineCount = Math.min(commandLineCount, COMMAND_EDITOR_LINE_NUMBER_LIMIT);
+            const labels = Array.from({ length: renderedLineCount }, (_, index) => String(index + 1));
+
+            if (commandLineCount > renderedLineCount) {
+                labels.push(`+${commandLineCount - renderedLineCount}`);
+            }
+
+            return labels;
+        }
+
+        if (commandLineCount <= COMMAND_EDITOR_COLLAPSED_LINES) {
             return Array.from({ length: commandLineCount }, (_, index) => String(index + 1));
         }
 
@@ -96,6 +110,13 @@ const ExecContent = () => {
             `+${remainingLines}`,
         ];
     }, [commandFocused, commandLineCount]);
+
+    const commandEditorStyle = useMemo<CSSProperties>(() => ({
+        [COMMAND_EDITOR_LINE_HEIGHT_VAR]: "1.5rem",
+        [COMMAND_EDITOR_VERTICAL_PADDING_VAR]: "1.5rem",
+        height: commandEditorHeight,
+        maxHeight: commandFocused ? "60vh" : COMMAND_EDITOR_COLLAPSED_HEIGHT,
+    }), [commandEditorHeight, commandFocused]);
 
     // 清理轮询的函数
     const clearPolling = () => {
@@ -125,12 +146,15 @@ const ExecContent = () => {
 
         if (!commandFocused) {
             textarea.scrollTop = 0;
+            if (commandLineGutterRef.current) {
+                commandLineGutterRef.current.scrollTop = 0;
+            }
             setCommandEditorHeight(COMMAND_EDITOR_COLLAPSED_HEIGHT);
             return;
         }
 
         textarea.style.height = "auto";
-        setCommandEditorHeight(Math.max(COMMAND_EDITOR_COLLAPSED_HEIGHT, textarea.scrollHeight));
+        setCommandEditorHeight(`${textarea.scrollHeight}px`);
         textarea.style.height = "100%";
     }, [command, commandFocused]);
 
@@ -231,6 +255,7 @@ const ExecContent = () => {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
+                    // Remote exec treats whitespace as script content, so preserve the user's exact input.
                     command,
                     clients: selectedNodes,
                 }),
@@ -314,16 +339,17 @@ const ExecContent = () => {
             <Card className="p-6">
                 <Flex direction="column" gap="4">
 
-                    <label className="text-xl font-bold">
+                    <label htmlFor={COMMAND_EDITOR_ID} className="text-xl font-bold">
                         {t("exec.command")}
                     </label>
                     <div
                         className="grid grid-cols-[3.75rem_minmax(0,1fr)] overflow-hidden rounded-md border border-[var(--gray-a7)] bg-[var(--color-surface)] transition-[height,border-color,box-shadow] duration-200 focus-within:border-[var(--accent-8)] focus-within:shadow-[0_0_0_1px_var(--accent-8)]"
-                        style={{ height: commandEditorHeight }}
+                        style={commandEditorStyle}
                     >
                         <div
+                            ref={commandLineGutterRef}
                             aria-hidden="true"
-                            className="select-none overflow-hidden border-r border-[var(--gray-a5)] bg-[var(--gray-2)] px-2 py-3 text-right font-mono text-xs leading-6 text-[var(--gray-11)]"
+                            className="select-none overflow-hidden border-r border-[var(--gray-a5)] bg-[var(--gray-2)] px-2 text-right font-mono text-xs text-[var(--gray-11)] [line-height:var(--command-editor-line-height)] [padding-bottom:calc(var(--command-editor-vertical-padding)/2)] [padding-top:calc(var(--command-editor-vertical-padding)/2)]"
                         >
                             {commandLineLabels.map((label, index) => (
                                 <div
@@ -335,19 +361,26 @@ const ExecContent = () => {
                             ))}
                         </div>
                         <textarea
+                            id={COMMAND_EDITOR_ID}
                             ref={commandTextareaRef}
                             value={command}
                             onChange={(e) => setCommand(e.target.value)}
                             onFocus={() => setCommandFocused(true)}
                             onBlur={() => setCommandFocused(false)}
                             onKeyDown={handleCommandKeyDown}
+                            onScroll={(event) => {
+                                if (commandLineGutterRef.current) {
+                                    commandLineGutterRef.current.scrollTop = event.currentTarget.scrollTop;
+                                }
+                            }}
                             placeholder={t("exec.commandPlaceholder")}
                             rows={COMMAND_EDITOR_COLLAPSED_LINES}
                             wrap="soft"
                             spellCheck={false}
-                            className="h-full w-full resize-none border-0 bg-transparent px-3 py-3 font-mono text-sm leading-6 text-[var(--gray-12)] outline-none placeholder:text-[var(--gray-9)]"
+                            className="h-full w-full resize-none border-0 bg-transparent px-3 font-mono text-sm text-[var(--gray-12)] outline-none placeholder:text-[var(--gray-9)] [line-height:var(--command-editor-line-height)] [padding-bottom:calc(var(--command-editor-vertical-padding)/2)] [padding-top:calc(var(--command-editor-vertical-padding)/2)]"
                             style={{
-                                overflowY: "hidden",
+                                maxHeight: commandFocused ? "60vh" : COMMAND_EDITOR_COLLAPSED_HEIGHT,
+                                overflowY: commandFocused ? "auto" : "hidden",
                                 overflowWrap: "break-word",
                                 whiteSpace: "pre-wrap",
                             }}


### PR DESCRIPTION
TLDR: 修复 https://github.com/komari-monitor/komari-web/pull/72 Github Copilot 自动 review 提出的问题
~老大你好快 我force-push上去发现PR已经merge了~

---

## 变更说明

本 PR 是对已合并的多行远程命令输入支持的跟进修复，主要根据评审反馈完善命令编辑器的可访问性、长内容表现和性能稳定性。

主要改动：

- 为命令输入 textarea 增加稳定 id，并将 label 与输入框关联
- 聚焦状态下限制编辑器最大高度，超出后在输入框内部滚动
- 限制超大脚本时渲染的行号数量，避免大量 DOM 节点影响输入性能
- 同步行号栏与输入框滚动位置
- 为行高和内边距常量增加说明，避免后续样式变更导致高度计算漂移
- 明确保留原始命令空白内容，因为远程命令会按脚本内容执行