### PR TITLE
fix: 修复 Web 生成安装命令时参数未安全引用的问题

### DIFF
--- a/src/components/admin/NodeTable/NodeFunction.tsx
+++ b/src/components/admin/NodeTable/NodeFunction.tsx
@@ -6,6 +6,7 @@ import { Terminal, Trash2, Copy, Download, DollarSign } from "lucide-react";
 import { t } from "i18next";
 import type { Row } from "@tanstack/react-table";
 import { EditDialog } from "./NodeEditDialog";
+import { quotePowerShellArg, quoteShellArgs } from "@/utils/shellQuote";
 import {
   Button,
   Checkbox,
@@ -63,20 +64,23 @@ export function ActionsCell({ row }: { row: Row<z.infer<typeof schema>> }) {
     if (installOptions.ignoreUnsafeCert) {
       args.push("--ignore-unsafe-cert");
     }
-    if (installOptions.ghproxy) {
-      if (!installOptions.ghproxy.startsWith("http")) {
-        installOptions.ghproxy = `http://${installOptions.ghproxy}`;
-      }
+    const ghproxy = installOptions.ghproxy.trim();
+    if (ghproxy) {
+      const finalGhproxy = ghproxy.startsWith("http")
+        ? ghproxy
+        : `http://${ghproxy}`;
       args.push(`--install-ghproxy`);
-      args.push(installOptions.ghproxy);
+      args.push(finalGhproxy);
     }
-    if (installOptions.dir) {
+    const installDir = installOptions.dir.trim();
+    if (installDir) {
       args.push(`--install-dir`);
-      args.push(installOptions.dir);
+      args.push(installDir);
     }
-    if (installOptions.serviceName) {
+    const serviceName = installOptions.serviceName.trim();
+    if (serviceName) {
       args.push(`--install-service-name`);
-      args.push(installOptions.serviceName);
+      args.push(serviceName);
     }
 
     let finalCommand = "";
@@ -84,7 +88,7 @@ export function ActionsCell({ row }: { row: Row<z.infer<typeof schema>> }) {
       case "linux":
         finalCommand =
           `wget -qO- https://raw.githubusercontent.com/komari-monitor/komari-agent/refs/heads/main/install.sh | sudo bash -s -- ` +
-          args.join(" ");
+          quoteShellArgs(args);
         break;
       case "windows":
         finalCommand =
@@ -93,14 +97,14 @@ export function ActionsCell({ row }: { row: Row<z.infer<typeof schema>> }) {
           ` -UseBasicParsing -OutFile 'install.ps1'; &` +
           ` '.\\install.ps1'`;
         args.forEach((arg) => {
-          finalCommand += ` '${arg}'`;
+          finalCommand += ` ${quotePowerShellArg(arg)}`;
         });
         finalCommand += `"`;
         break;
       case "macos":
         finalCommand =
-            `zsh <(curl -sL https://raw.githubusercontent.com/komari-monitor/komari-agent/refs/heads/main/install.sh) ` +
-            args.join(" ");
+          `zsh <(curl -sL https://raw.githubusercontent.com/komari-monitor/komari-agent/refs/heads/main/install.sh) ` +
+          quoteShellArgs(args);
         break;
     }
     return finalCommand;

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,3 +1,8 @@
+import {
+  quotePowerShellArg,
+  quoteShellArg,
+  quoteShellArgs,
+} from "@/utils/shellQuote";
 import React, { useEffect, useState } from "react";
 import {
   NodeDetailsProvider,
@@ -627,34 +632,40 @@ function GenerateCommandButton({ node, settings }: { node: NodeDetail, settings:
     if (installOptions.enableGpu) {
       args.push("--gpu");
     }
-    if (enableGhproxy && installOptions.ghproxy) {
+    const ghproxy = installOptions.ghproxy.trim();
+    if (enableGhproxy && ghproxy) {
       const finalUrl = (
-        installOptions.ghproxy.startsWith("http")
-          ? installOptions.ghproxy
-          : `http://${installOptions.ghproxy}`
+        ghproxy.startsWith("http")
+          ? ghproxy
+          : `http://${ghproxy}`
       ).replace(/\/+$/, "");
       args.push(`--install-ghproxy`);
       args.push(finalUrl);
     }
-    if (enableCustomDir && installOptions.dir) {
+    const installDir = installOptions.dir.trim();
+    if (enableCustomDir && installDir) {
       args.push(`--install-dir`);
-      args.push(installOptions.dir);
+      args.push(installDir);
     }
-    if (enableCustomServiceName && installOptions.serviceName) {
+    const serviceName = installOptions.serviceName.trim();
+    if (enableCustomServiceName && serviceName) {
       args.push(`--install-service-name`);
-      args.push(installOptions.serviceName);
+      args.push(serviceName);
     }
-    if (enableIncludeNics && installOptions.includeNics) {
+    const includeNics = installOptions.includeNics.trim();
+    if (enableIncludeNics && includeNics) {
       args.push(`--include-nics`);
-      args.push(installOptions.includeNics);
+      args.push(includeNics);
     }
-    if (enableExcludeNics && installOptions.excludeNics) {
+    const excludeNics = installOptions.excludeNics.trim();
+    if (enableExcludeNics && excludeNics) {
       args.push(`--exclude-nics`);
-      args.push(installOptions.excludeNics);
+      args.push(excludeNics);
     }
-    if (enableIncludeMountpoints && installOptions.includeMountpoints) {
+    const includeMountpoints = installOptions.includeMountpoints.trim();
+    if (enableIncludeMountpoints && includeMountpoints) {
       args.push(`--include-mountpoint`);
-      args.push(installOptions.includeMountpoints);
+      args.push(includeMountpoints);
     }
     if (enableInterval) {
       const intervalVal = Number.parseFloat((installOptions.interval || "").trim());
@@ -673,12 +684,12 @@ function GenerateCommandButton({ node, settings }: { node: NodeDetail, settings:
     let scriptUrl =
       `https://raw.githubusercontent.com/komari-monitor/komari-agent/refs/heads/main/${scriptFile}`;
     if (enableGhproxy) {
-      if (enableGhproxy && installOptions.ghproxy) {
+      if (enableGhproxy && ghproxy) {
         scriptUrl = scriptUrl.slice(8); // 去掉 https://
-        if (installOptions.ghproxy.endsWith("/")) {
-          scriptUrl = `${installOptions.ghproxy}${scriptUrl}`;
+        if (ghproxy.endsWith("/")) {
+          scriptUrl = `${ghproxy}${scriptUrl}`;
         } else {
-          scriptUrl = `${installOptions.ghproxy}/${scriptUrl}`;
+          scriptUrl = `${ghproxy}/${scriptUrl}`;
         }
         if (!scriptUrl.startsWith("http")) {
           scriptUrl = `http://${scriptUrl}`;
@@ -688,21 +699,24 @@ function GenerateCommandButton({ node, settings }: { node: NodeDetail, settings:
     let finalCommand = "";
     switch (selectedPlatform) {
       case "linux":
-        finalCommand = `wget -qO- ${scriptUrl} | sudo bash -s -- ` + args.join(" ");
+        finalCommand =
+          `wget -qO- ${quoteShellArg(scriptUrl)} | sudo bash -s -- ` +
+          quoteShellArgs(args);
         break;
       case "windows":
         finalCommand =
           `powershell.exe -NoProfile -ExecutionPolicy Bypass -Command ` +
-          `"iwr '${scriptUrl}'` +
+          `"iwr ${quotePowerShellArg(scriptUrl)}` +
           ` -UseBasicParsing -OutFile 'install.ps1'; &` +
           ` '.\\install.ps1'`;
         args.forEach((arg) => {
-          finalCommand += ` '${arg}'`;
+          finalCommand += ` ${quotePowerShellArg(arg)}`;
         });
         finalCommand += `"`;
         break;
       case "macos":
-        finalCommand = `zsh <(curl -sL ${scriptUrl}) ` + args.join(" ");
+        finalCommand =
+          `zsh <(curl -sL ${quoteShellArg(scriptUrl)}) ` + quoteShellArgs(args);
         break;
     }
     return finalCommand;

--- a/src/utils/shellQuote.ts
+++ b/src/utils/shellQuote.ts
@@ -1,0 +1,23 @@
+const shellUnsafePattern = /[\s"'\\$`!#&*();<>?[\]^{|}~]/;
+
+export function quoteShellArg(value: string) {
+  const trimmedValue = value.trim();
+
+  if (trimmedValue === "") {
+    return "''";
+  }
+
+  if (!shellUnsafePattern.test(trimmedValue)) {
+    return trimmedValue;
+  }
+
+  return `'${trimmedValue.replace(/'/g, `'\\''`)}'`;
+}
+
+export function quoteShellArgs(args: string[]) {
+  return args.map(quoteShellArg).join(" ");
+}
+
+export function quotePowerShellArg(value: string) {
+  return `'${value.trim().replace(/'/g, "''")}'`;
+}


### PR DESCRIPTION
指定多挂载点时, 采用分号分隔但未做引用, 将导致安装命令被截断:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/3bdc2860-b275-44b5-9f6c-b95ef88a477b" />

本 PR 为 Web UI 中生成的一键安装命令增加统一的参数引用处理。

主要变更：
- 新增 Shell/PowerShell 参数引用工具函数。
- 对 Linux、macOS、Windows 安装命令中的动态参数进行 trim 和安全引用。
- 避免挂载点、安装目录、服务名、代理地址等用户输入中包含空格、分号或其他特殊字符时导致命令被 shell 错误解析。
- 同步修复旧的节点表操作组件中的安装命令生成逻辑。
