### PR TITLE
fix(build): force @xterm/xterm to CJS to fix ReferenceError in vi

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -122,9 +122,14 @@ export default defineConfig(({ mode }) => {
       __BUILD_TIME__: JSON.stringify(buildTime),
     },
     resolve: {
-      alias: {
-        "@": path.resolve(__dirname, "./src"),
-      },
+      alias: [
+        { find: "@", replacement: path.resolve(__dirname, "./src") },
+        // Force xterm to use the CJS build to avoid a rollup bug where `||=` in
+        // xterm.mjs is incorrectly lowered to `void 0||(i={})` with an undeclared `i`,
+        // causing `ReferenceError: i is not defined` at requestMode when vi sends DECRQM sequences.
+        // Regex to match only the bare specifier, not subpaths like @xterm/xterm/css/xterm.css.
+        { find: /^@xterm\/xterm$/, replacement: path.resolve(__dirname, "node_modules/@xterm/xterm/lib/xterm.js") },
+      ],
     },
     build: {
       assetsDir: "assets",


### PR DESCRIPTION
## Summary

- `@xterm/xterm@6.0.0` 的 ESM 产物（`xterm.mjs`）在 `requestMode` 里使用了 `||=` 运算符
- rollup 将其错误地转换为 `void 0||(i={})`, `i` 在模块作用域中从未声明，ESM 严格模式下抛出 `ReferenceError: i is not defined`
- `vi` 会发送 DECRQM 终端模式查询序列从而触发 `requestMode`，`btop` 不发，因此仅在使用 `vi` 时复现

## Fix

在 `vite.config.ts` 中用 regex alias 将 `@xterm/xterm` 裸导入指向 CJS 版本 `lib/xterm.js`，该版本不使用 `||=`，不受此 rollup bug 影响。子路径导入（如 `@xterm/xterm/css/xterm.css`）不受影响。

## Test plan

- [ ] 构建成功，无 TS 错误
- [ ] 终端页面正常打开
- [ ] 在终端中使用 `vi` 不再出现 `ReferenceError: i is not defined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)