### PR TITLE
fix(admin): gate admin layout behind auth check (#585)

### DIFF
--- a/src/components/admin/AdminPanelBar.tsx
+++ b/src/components/admin/AdminPanelBar.tsx
@@ -20,9 +20,9 @@ import type { MenuItem } from "../../types/menu";
 import { iconMap } from "../../utils/iconHelper";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { TablerMenu2 } from "../Icones/Tabler";
-import LoginDialog from "../Login";
-import { useAccount } from "@/contexts/AccountContext";
 import { usePublicInfo } from "@/contexts/PublicInfoContext";
+// NOTE: 鉴权守卫已移至 AdminLayout（AdminGuard），到达本组件时必定已登录，
+// 故不再需要 account/LoginDialog 来处理未登录态（修复 #585）。
 import Tips from "../ui/tips";
 import { CircleFadingArrowUp } from "lucide-react";
 import { useRPC2Call } from "@/contexts/RPC2Context";
@@ -54,7 +54,6 @@ const AdminPanelBar = ({ content }: AdminPanelBarProps) => {
   const [openSubMenus, setOpenSubMenus] = useState<{ [key: string]: boolean }>({
     // 默认所有子菜单关闭
   });
-  const { account } = useAccount();
   const isMobile = useIsMobile();
   const ishttps = window.location.protocol === "https:";
   const [t, i18n] = useTranslation();
@@ -411,15 +410,6 @@ const AdminPanelBar = ({ content }: AdminPanelBarProps) => {
               </label>
             </Flex>
             <Flex gap="3" align="center" overflowX="auto">
-              {account && !account.logged_in && (
-                <LoginDialog
-                  autoOpen={true}
-                  showSettings={false}
-                  onLoginSuccess={() => {
-                    window.location.reload();
-                  }}
-                />
-              )}
               <ThemeSwitch />
               <ColorSwitch />
               <LanguageSwitch />

--- a/src/pages/admin/_layout.tsx
+++ b/src/pages/admin/_layout.tsx
@@ -1,12 +1,50 @@
 import { Outlet } from "react-router-dom";
 
 import AdminPanelBar from "../../components/admin/AdminPanelBar";
-import { AccountProvider } from "@/contexts/AccountContext";
+import LoginDialog from "../../components/Login";
+import { AccountProvider, useAccount } from "@/contexts/AccountContext";
 import { updateSettingsWithToast, useSettings } from "@/lib/api";
-import { Button, Dialog } from "@radix-ui/themes";
+import { Button, Dialog, Flex, Spinner } from "@radix-ui/themes";
 import { useEffect, useState } from "react";
 import { Eula } from "@/utils/field";
 import { normalizeLanguage, readStoredLanguage } from "@/utils/language";
+
+// AdminGuard 在后台框架渲染前进行鉴权：
+// - loading 中：仅显示加载占位，不渲染后台框架
+// - 未登录：仅显示登录框（不渲染后台框架/侧边栏，避免框架泄露）
+// - 已登录：正常渲染后台
+//
+// 修复 #585：此前 AdminLayout 直接渲染 AdminPanelBar，其内部的 AccountProvider
+// 在 /api/me 返回前 account 为 null，登录框条件 (account && !account.logged_in)
+// 不成立，导致未登录时后台框架先裸露出来。
+const AdminGuard = () => {
+  const { account, loading } = useAccount();
+
+  if (loading || !account) {
+    return (
+      <Flex align="center" justify="center" style={{ minHeight: "100vh" }}>
+        <Spinner size="3" />
+      </Flex>
+    );
+  }
+
+  if (!account.logged_in) {
+    return (
+      <Flex align="center" justify="center" style={{ minHeight: "100vh" }}>
+        <LoginDialog
+          autoOpen={true}
+          showSettings={false}
+          onLoginSuccess={() => {
+            window.location.reload();
+          }}
+        />
+      </Flex>
+    );
+  }
+
+  return <AdminPanelBar content={<Outlet />} />;
+};
+
 const AdminLayout = () => {
   const { settings, loading } = useSettings();
   const lang = readStoredLanguage() || "en";
@@ -59,7 +97,7 @@ const AdminLayout = () => {
         </Dialog.Content>
       </Dialog.Root>
       <AccountProvider>
-        <AdminPanelBar content={<Outlet />} />
+        <AdminGuard />
       </AccountProvider>
     </>
   );


### PR DESCRIPTION
## Summary

Fixes komari-monitor/komari#585.

> Note: the issue was filed in the **backend repo** (`komari-monitor/komari#585`), but the root cause is in this frontend repo (`komari-web`), so the fix lives here.

When visiting `/admin` without a session, the admin framework (nav bar + sidebar) was painted **before** any login prompt, and the auto-opened login dialog could be dismissed by clicking outside it — leaving the empty admin shell exposed (the reporter notes all actions still return 401, so it's an information/UX exposure, not an auth bypass).

## Root cause

`AdminLayout` rendered `AdminPanelBar` immediately. `AdminPanelBar` has its own `AccountProvider`, but until `/api/me` resolved, `account` was `null`, so the login-dialog guard `account && !account.logged_in` evaluated to `false` during loading — no login prompt, full framework visible.

## Fix

Introduce an `AdminGuard` inside `AccountProvider` in `_layout.tsx` that gates rendering on the **resolved** account state:

| state | render |
|---|---|
| loading / unresolved | centered spinner — **no admin framework** |
| not logged in | centered login dialog only — **no admin framework** |
| logged in | `AdminPanelBar` as before |

The now-unreachable login-dialog branch in `AdminPanelBar` (which only ran for `!account.logged_in`, impossible once the guard is in place) is removed, along with its now-unused `account`/`LoginDialog`/`useAccount` references.

Per the issue's expected behavior, unauthenticated users stay on `/admin` and get just the login dialog (no redirect).

## Verification

- `tsc -b` — no errors
- `vite build` — succeeds
- `eslint` — 0 errors (3 pre-existing warnings unrelated to this change)
