### PR TITLE
feat: add traffic reset day countdown (TRD)

### DIFF
--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next";
 import Tips from "./ui/tips";
 
 import { formatBytes } from "@/utils/unitHelper";
+import { parseTRDFromTags, daysUntilTrafficReset } from "@/utils/trafficReset";
 
 /** 格式化秒*/
 export function formatUptime(seconds: number, t: TFunction): string {
@@ -69,6 +70,8 @@ const Node = React.memo(
   const downloadSpeed = formatBytes(liveData.network.down);
   const totalUpload = formatBytes(liveData.network.totalUp);
   const totalDownload = formatBytes(liveData.network.totalDown);
+  const resetDay = parseTRDFromTags(basic.tags);
+  const daysUntilReset = daysUntilTrafficReset(resetDay);
   //const totalTraffic = formatBytes(liveData.network.totalUp + liveData.network.totalDown);
   return (
     <Card
@@ -206,12 +209,23 @@ const Node = React.memo(
                 <Text size="1" className="md:block hidden" color="gray">
                   ↑ {totalUpload} ↓ {totalDownload}
                 </Text>
-                <Text size="1" className="md:block hidden" color="gray">
-                  {basic.traffic_limit_type &&
-                    basic.traffic_limit_type.charAt(0).toUpperCase() +
-                      basic.traffic_limit_type.slice(1)}
-                  ({formatBytes(basic.traffic_limit)})
-                </Text>
+                <Flex direction="column" align="end" gap="0">
+                  <Text size="1" className="md:block hidden" color="gray">
+                    {basic.traffic_limit_type &&
+                      basic.traffic_limit_type.charAt(0).toUpperCase() +
+                        basic.traffic_limit_type.slice(1)}
+                    ({formatBytes(basic.traffic_limit)})
+                  </Text>
+                  {daysUntilReset !== undefined && (
+                    <Text size="1" className="md:block hidden" color="gray">
+                      {daysUntilReset === 0
+                        ? t("nodeCard.trafficResetToday")
+                        : t("nodeCard.trafficResetIn", {
+                            days: daysUntilReset,
+                          })}
+                    </Text>
+                  )}
+                </Flex>
               </Flex>
             </Flex>
           ) : (
@@ -249,16 +263,25 @@ const Node = React.memo(
             </Flex>
           </Flex>
           {basic.traffic_limit > 0 && isMobile && (
-            <UsageBar
-              label={`${basic.traffic_limit_type && basic.traffic_limit_type.charAt(0).toUpperCase() + basic.traffic_limit_type.slice(1)}(${formatBytes(basic.traffic_limit)})`}
-              max={Infinity}
-              value={getTrafficPercentage(
-                liveData.network.totalUp,
-                liveData.network.totalDown,
-                basic.traffic_limit,
-                basic.traffic_limit_type ?? "sum",
+            <Flex direction="column" gap="1">
+              <UsageBar
+                label={`${basic.traffic_limit_type && basic.traffic_limit_type.charAt(0).toUpperCase() + basic.traffic_limit_type.slice(1)}(${formatBytes(basic.traffic_limit)})`}
+                max={Infinity}
+                value={getTrafficPercentage(
+                  liveData.network.totalUp,
+                  liveData.network.totalDown,
+                  basic.traffic_limit,
+                  basic.traffic_limit_type ?? "sum",
+                )}
+              />
+              {daysUntilReset !== undefined && (
+                <Text size="1" color="gray">
+                  {daysUntilReset === 0
+                    ? t("nodeCard.trafficResetToday")
+                    : t("nodeCard.trafficResetIn", { days: daysUntilReset })}
+                </Text>
               )}
-            />
+            </Flex>
           )}
           <Flex justify="between" hidden={isMobile}>
             <Text size="2" color="gray">

--- a/src/components/PriceTags.tsx
+++ b/src/components/PriceTags.tsx
@@ -123,7 +123,10 @@ const CustomTags = ({ tags }: { tags?: string }) => {
   if (!tags || tags.trim() === "") {
     return <></>;
   }
-  const tagList = tags.split(";").filter((tag) => tag.trim() !== "");
+  const tagList = tags
+    .split(";")
+    .filter((tag) => tag.trim() !== "")
+    .filter((tag) => !/^<TRD:\d+>$/i.test(tag.trim()));
   const colors: Array<
     | "ruby"
     | "gray"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -625,6 +625,8 @@
     "totalDownload": "Total Download",
     "totalNodes": "{{total}} servers total, {{online}} online",
     "totalTraffic": "Traffic",
+    "trafficResetToday": "Resets today",
+    "trafficResetIn": "{{days}} days to reset",
     "totalUpload": "Total Upload",
     "uptime": "Uptime",
     "virtualization": "Virtualization"

--- a/src/i18n/locales/id_ID.json
+++ b/src/i18n/locales/id_ID.json
@@ -625,6 +625,8 @@
     "totalDownload": "Total Unduhan",
     "totalNodes": "Total {{total}} server, {{online}} Hidup",
     "totalTraffic": "Total Lalu Lintas",
+    "trafficResetToday": "Reset hari ini",
+    "trafficResetIn": "{{days}} hari lagi reset",
     "totalUpload": "Total Unggahan",
     "uptime": "Waktu Aktif",
     "virtualization": "Virtualisasi"

--- a/src/i18n/locales/ja_JP.json
+++ b/src/i18n/locales/ja_JP.json
@@ -625,6 +625,8 @@
     "totalDownload": "総ダウンロード",
     "totalNodes": "合計 {{total}} 台のサーバー、{{online}} 台がオンライン",
     "totalTraffic": "総トラフィック",
+    "trafficResetToday": "本日リセット",
+    "trafficResetIn": "{{days}}日後にリセット",
     "totalUpload": "総アップロード",
     "uptime": "稼働時間",
     "virtualization": "仮想化"

--- a/src/i18n/locales/zh_CN.json
+++ b/src/i18n/locales/zh_CN.json
@@ -625,6 +625,8 @@
     "totalDownload": "总下载",
     "totalNodes": "共 {{total}} 个服务器，{{online}} 个在线",
     "totalTraffic": "总流量",
+    "trafficResetToday": "今日重置",
+    "trafficResetIn": "{{days}}天后重置",
     "totalUpload": "总上传",
     "uptime": "运行时间",
     "virtualization": "虚拟化"

--- a/src/i18n/locales/zh_TW.json
+++ b/src/i18n/locales/zh_TW.json
@@ -625,6 +625,8 @@
     "totalDownload": "總下載",
     "totalNodes": "共 {{total}} 個伺服器，{{online}} 個線上",
     "totalTraffic": "總流量",
+    "trafficResetToday": "今日重置",
+    "trafficResetIn": "{{days}}天後重置",
     "totalUpload": "總上傳",
     "uptime": "運作時間",
     "virtualization": "虛擬化"

--- a/src/utils/trafficReset.ts
+++ b/src/utils/trafficReset.ts
@@ -1,0 +1,110 @@
+/**
+ * 流量重置日倒计时工具
+ * 参考: https://github.com/nuomiiiii/nezha (src/lib/trafficReset.ts)
+ *
+ * 重置日来源: 服务器标签中的 <TRD:n> 元标签
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * 计算指定年份月份中重置日对应的实际日期。
+ * 若重置日超出当月天数（如2月的31日），则回退到次月1日。
+ */
+function actualResetDate(year: number, month: number, resetDay: number): Date {
+  const lastDay = new Date(year, month + 1, 0).getDate();
+  if (resetDay <= lastDay) return new Date(year, month, resetDay);
+  return new Date(year, month + 1, 1);
+}
+
+function sameCalendarDay(left: Date, right: Date): boolean {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  );
+}
+
+function calendarDayDistance(from: Date, to: Date): number {
+  const fromUTC = Date.UTC(from.getFullYear(), from.getMonth(), from.getDate());
+  const toUTC = Date.UTC(to.getFullYear(), to.getMonth(), to.getDate());
+  return Math.max(0, Math.round((toUTC - fromUTC) / DAY_MS));
+}
+
+/**
+ * 计算距离下次流量重置还有多少天。
+ *
+ * @param resetDay - 每月重置日（1-31），无效值返回 undefined
+ * @param now - 当前时间（用于测试覆盖）
+ * @returns 剩余天数（0 = 今日重置），undefined 表示未配置
+ *
+ * @example
+ * daysUntilTrafficReset(1, new Date('2025-01-15'))   // 17
+ * daysUntilTrafficReset(1, new Date('2025-02-01'))   // 0
+ * daysUntilTrafficReset(31, new Date('2025-02-15')) // 14（2月无31日，回退到3月1日）
+ */
+export function daysUntilTrafficReset(
+  resetDay?: number,
+  now: Date = new Date(),
+): number | undefined {
+  if (
+    !Number.isInteger(resetDay) ||
+    !resetDay ||
+    resetDay < 1 ||
+    resetDay > 31
+  ) {
+    return undefined;
+  }
+
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const thisMonth = actualResetDate(
+    today.getFullYear(),
+    today.getMonth(),
+    resetDay,
+  );
+  const previousMonth = actualResetDate(
+    today.getFullYear(),
+    today.getMonth() - 1,
+    resetDay,
+  );
+
+  if (sameCalendarDay(today, thisMonth) || sameCalendarDay(today, previousMonth)) {
+    return 0;
+  }
+  if (today < thisMonth) {
+    return calendarDayDistance(today, thisMonth);
+  }
+
+  const nextMonth = actualResetDate(
+    today.getFullYear(),
+    today.getMonth() + 1,
+    resetDay,
+  );
+  return calendarDayDistance(today, nextMonth);
+}
+
+/**
+ * 从服务器标签中解析 <TRD:n> 元标签，提取流量重置日。
+ * 标签格式参考 nezha 主题：在服务器标签中加入 <TRD:1> 表示每月1日重置。
+ *
+ * @param tags - 服务器标签字符串，多个标签以 ';' 分隔
+ * @returns 重置日（1-31），未找到返回 undefined
+ *
+ * @example
+ * parseTRDFromTags("So-net<red>;1Gbps<green>;<TRD:1>")  // 1
+ * parseTRDFromTags("So-net;<TRD:15>")                   // 15
+ * parseTRDFromTags("no-trd-here")                       // undefined
+ */
+export function parseTRDFromTags(tags?: string): number | undefined {
+  if (!tags || tags.trim() === "") return undefined;
+
+  const tagList = tags.split(";");
+  for (const tag of tagList) {
+    const match = tag.trim().match(/^<TRD:(\d+)>$/i);
+    if (match) {
+      const day = parseInt(match[1], 10);
+      if (day >= 1 && day <= 31) return day;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## 概述

大佬，你好。实现了流量重置日倒计时功能，请求合并。参考 [nuomiiiii/nezha](https://github.com/nuomiiiii/nezha) 主题的 TRD 实现。当服务器配置了流量重置日期 `<TRD:n>` 元标签，在首页服务器卡片显示距离下次流量重置的剩余天数。

## 改动

- **新增 `src/utils/trafficReset.ts`**：核心工具函数，从 nezha 主题移植 `daysUntilTrafficReset` 日期计算逻辑；新增 `<TRD:n>` 标签解析器
- **`Node.tsx`**：首页服务器卡片流量区域显示倒计时文本，桌面端在流量类型/限额右侧，移动端在 UsageBar 下方
- **`PriceTags.tsx`**：过滤 `<TRD:n>` 元标签，防止其渲染为可见TAG
- **i18n**：en / zh_CN / zh_TW / ja_JP / id_ID 五个语言文件新增 `trafficReset`、`trafficResetToday`、`trafficResetIn` 三个键

## 重置日来源


1. 服务器标签中的 `<TRD:n>` 元标签（如 `<TRD:1>` 表示每月 1 日重置）

## 效果图
<img width="594" height="868" alt="image" src="https://github.com/user-attachments/assets/2e3b800d-6f6b-42f2-8c95-2d8fc18ba426" />
